### PR TITLE
Chapter 2: Testing presentation

### DIFF
--- a/Chapter2/TCAContacts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Chapter2/TCAContacts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "3568f01377c6c668aad40d066acf97ce670a1dad",
-        "version" : "1.5.6"
+        "revision" : "ae491c9e3f66631e72d58db8bb4c27dfc3d3afd4",
+        "version" : "1.6.0"
       }
     },
     {

--- a/Chapter2/TCAContactsKit/Package.swift
+++ b/Chapter2/TCAContactsKit/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["TCAContactsKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.5.6"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.6.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/AddContactFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/AddContactFeature.swift
@@ -17,6 +17,7 @@ struct AddContactFeature {
     }
 
     enum Action {
+        @CasePathable
         enum Delegate: Equatable {
             case saveContact(Contact)
         }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -31,6 +31,8 @@ struct ContactsFeature {
         case destination(PresentationAction<Destination.Action>)
     }
 
+    @Dependency(\.uuid) var uuid
+
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -39,7 +39,7 @@ struct ContactsFeature {
             case .addButtonTapped:
                 state.destination = .addContact(
                     AddContactFeature.State(
-                        contact: Contact(id: UUID(), name: "")
+                        contact: Contact(id: self.uuid(), name: "")
                     )
                 )
                 return .none

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -56,15 +56,7 @@ struct ContactsFeature {
                 return .none
 
             case .deleteButtonTapped(let id):
-                state.destination = .alert(
-                    AlertState {
-                        TextState("Are you sure?")
-                    } actions: {
-                        ButtonState(role: .destructive, action: .confirmDeletion(id: id)) {
-                            TextState("Delete")
-                        }
-                    }
-                )
+                state.destination = .alert(.deleteConfirmation(id: id))
                 return .none
             }
         }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -97,6 +97,19 @@ extension ContactsFeature {
     }
 }
 
+extension AlertState where Action == ContactsFeature.Action.Alert {
+
+    static func deleteConfirmation(id: UUID) -> Self {
+        Self {
+            TextState("Are you sure?")
+        } actions: {
+            ButtonState(role: .destructive, action: .confirmDeletion(id: id)) {
+                TextState("Delete")
+            }
+        }
+    }
+}
+
 struct ContactsView: View {
 
     let store: StoreOf<ContactsFeature>

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -23,7 +23,7 @@ final class ContactsFeatureTests: XCTestCase {
         await store.send(.addButtonTapped) {
             $0.destination = .addContact(
                 AddContactFeature.State(
-                    contact: Contact(id: ???, name: "")
+                    contact: Contact(id: UUID(0), name: "")
                 )
             )
         }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -28,6 +28,7 @@ final class ContactsFeatureTests: XCTestCase {
             )
         }
         await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+            $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
         }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -77,15 +77,7 @@ final class ContactsFeatureTests: XCTestCase {
         }
 
         await store.send(.deleteButtonTapped(id: UUID(1))) {
-            $0.destination = .alert(
-                AlertState {
-                    TextState("Are you sure?")
-                } actions: {
-                    ButtonState(role: .destructive, action: .confirmDeletion(id: UUID(1))) {
-                        TextState("Delete")
-                    }
-                }
-            )
+            $0.destination = .alert(.deleteConfirmation(id: UUID(1)))
         }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -56,5 +56,11 @@ final class ContactsFeatureTests: XCTestCase {
         await store.send(.destination(.presented(.addContact(.setName("Blob Jr.")))))
         await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
         await store.skipReceivedActions()
+        store.assert {
+            $0.contacts = [
+                Contact(id: UUID(0), name: "Blob Jr.")
+            ]
+            $0.destination = nil
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -35,6 +35,9 @@ final class ContactsFeatureTests: XCTestCase {
             \.destination.addContact.delegate.saveContact,
             Contact(id: UUID(0), name: "Blob Jr.")
         ) {
+            $0.contacts = [
+                Contact(id: UUID(0), name: "Blob Jr.")
+            ]
         }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -20,6 +20,8 @@ final class ContactsFeatureTests: XCTestCase {
 
         await store.send(.addButtonTapped) {
             $0.destination = .addContact(
+                AddContactFeature.State(
+                )
             )
         }
     }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -21,6 +21,7 @@ final class ContactsFeatureTests: XCTestCase {
         await store.send(.addButtonTapped) {
             $0.destination = .addContact(
                 AddContactFeature.State(
+                    contact: Contact(id: ???, name: "")
                 )
             )
         }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -65,5 +65,8 @@ final class ContactsFeatureTests: XCTestCase {
     }
 
     func testDeleteContact() async {
+        let store = TestStore(initialState: ContactsFeature.State()) {
+            ContactsFeature()
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -65,7 +65,14 @@ final class ContactsFeatureTests: XCTestCase {
     }
 
     func testDeleteContact() async {
-        let store = TestStore(initialState: ContactsFeature.State()) {
+        let store = TestStore(
+            initialState: ContactsFeature.State(
+                contacts: [
+                    Contact(id: UUID(0), name: "Blob"),
+                    Contact(id: UUID(1), name: "Blob Jr."),
+                ]
+            )
+        ) {
             ContactsFeature()
         }
     }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -14,5 +14,8 @@ import XCTest
 final class ContactsFeatureTests: XCTestCase {
 
     func testAddFlow() async {
+        let store = TestStore(initialState: ContactsFeature.State()) {
+            ContactsFeature()
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -78,6 +78,13 @@ final class ContactsFeatureTests: XCTestCase {
 
         await store.send(.deleteButtonTapped(id: UUID(1))) {
             $0.destination = .alert(
+                AlertState {
+                    TextState("Are you sure?")
+                } actions: {
+                    ButtonState(role: .destructive, action: .confirmDeletion(id: UUID(1))) {
+                        TextState("Delete")
+                    }
+                }
             )
         }
     }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -27,5 +27,7 @@ final class ContactsFeatureTests: XCTestCase {
                 )
             )
         }
+        await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -30,5 +30,6 @@ final class ContactsFeatureTests: XCTestCase {
         await store.send(.destination(.presented(.addContact(.setName("Blob Jr."))))) {
             $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
         }
+        await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -77,6 +77,8 @@ final class ContactsFeatureTests: XCTestCase {
         }
 
         await store.send(.deleteButtonTapped(id: UUID(1))) {
+            $0.destination = .alert(
+            )
         }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -17,5 +17,8 @@ final class ContactsFeatureTests: XCTestCase {
         let store = TestStore(initialState: ContactsFeature.State()) {
             ContactsFeature()
         }
+
+        await store.send(.addButtonTapped) {
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -75,5 +75,8 @@ final class ContactsFeatureTests: XCTestCase {
         ) {
             ContactsFeature()
         }
+
+        await store.send(.deleteButtonTapped(id: UUID(1))) {
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -79,5 +79,7 @@ final class ContactsFeatureTests: XCTestCase {
         await store.send(.deleteButtonTapped(id: UUID(1))) {
             $0.destination = .alert(.deleteConfirmation(id: UUID(1)))
         }
+        await store.send(.destination(.presented(.alert(.confirmDeletion(id: UUID(1)))))) {
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -63,4 +63,7 @@ final class ContactsFeatureTests: XCTestCase {
             $0.destination = nil
         }
     }
+
+    func testDeleteContact() async {
+    }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -43,4 +43,12 @@ final class ContactsFeatureTests: XCTestCase {
             $0.destination = nil
         }
     }
+
+    func testAddFlow_NonExhaustive() async {
+        let store = TestStore(initialState: ContactsFeature.State()) {
+            ContactsFeature()
+        } withDependencies: {
+            $0.uuid = .incrementing
+        }
+    }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -31,5 +31,10 @@ final class ContactsFeatureTests: XCTestCase {
             $0.$destination[case: \.addContact]?.contact.name = "Blob Jr."
         }
         await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+        await store.receive(
+            \.destination.addContact.delegate.saveContact,
+            Contact(id: UUID(0), name: "Blob Jr.")
+        ) {
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -55,5 +55,6 @@ final class ContactsFeatureTests: XCTestCase {
         await store.send(.addButtonTapped)
         await store.send(.destination(.presented(.addContact(.setName("Blob Jr.")))))
         await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
+        await store.skipReceivedActions()
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -53,5 +53,6 @@ final class ContactsFeatureTests: XCTestCase {
         store.exhaustivity = .off
 
         await store.send(.addButtonTapped)
+        await store.send(.destination(.presented(.addContact(.setName("Blob Jr.")))))
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -54,5 +54,6 @@ final class ContactsFeatureTests: XCTestCase {
 
         await store.send(.addButtonTapped)
         await store.send(.destination(.presented(.addContact(.setName("Blob Jr.")))))
+        await store.send(.destination(.presented(.addContact(.saveButtonTapped))))
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -51,5 +51,7 @@ final class ContactsFeatureTests: XCTestCase {
             $0.uuid = .incrementing
         }
         store.exhaustivity = .off
+
+        await store.send(.addButtonTapped)
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -19,6 +19,8 @@ final class ContactsFeatureTests: XCTestCase {
         }
 
         await store.send(.addButtonTapped) {
+            $0.destination = .addContact(
+            )
         }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -50,5 +50,6 @@ final class ContactsFeatureTests: XCTestCase {
         } withDependencies: {
             $0.uuid = .incrementing
         }
+        store.exhaustivity = .off
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -39,6 +39,8 @@ final class ContactsFeatureTests: XCTestCase {
                 Contact(id: UUID(0), name: "Blob Jr.")
             ]
         }
-        await store.receive(\.destination.dismiss)
+        await store.receive(\.destination.dismiss) {
+            $0.destination = nil
+        }
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -16,6 +16,8 @@ final class ContactsFeatureTests: XCTestCase {
     func testAddFlow() async {
         let store = TestStore(initialState: ContactsFeature.State()) {
             ContactsFeature()
+        } withDependencies: {
+            $0.uuid = .incrementing
         }
 
         await store.send(.addButtonTapped) {

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -1,0 +1,18 @@
+//
+//  ContactsFeatureTests.swift
+//  
+//  
+//  Created by penguinsan on 2024/01/28
+//  
+//
+
+import ComposableArchitecture
+import XCTest
+@testable import TCAContactsKit
+
+@MainActor
+final class ContactsFeatureTests: XCTestCase {
+
+    func testAddFlow() async {
+    }
+}

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -39,5 +39,6 @@ final class ContactsFeatureTests: XCTestCase {
                 Contact(id: UUID(0), name: "Blob Jr.")
             ]
         }
+        await store.receive(\.destination.dismiss)
     }
 }

--- a/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
+++ b/Chapter2/TCAContactsKit/Tests/TCAContactsKitTests/ContactsFeatureTests.swift
@@ -80,6 +80,8 @@ final class ContactsFeatureTests: XCTestCase {
             $0.destination = .alert(.deleteConfirmation(id: UUID(1)))
         }
         await store.send(.destination(.presented(.alert(.confirmDeletion(id: UUID(1)))))) {
+            $0.contacts.remove(id: UUID(1))
+            $0.destination = nil
         }
     }
 }


### PR DESCRIPTION
## 概要

The Composable Architecture Tutorials の [Chapter 2 Navigation: Testing presentation](https://pointfreeco.github.io/swift-composable-architecture/main/tutorials/composablearchitecture/02-03-testingpresentation) を実施する。

Tutorial の途中でバージョン `1.5.6` では実装されていないメソッドが使われていたため、TCA のバージョンを最新 (`1.6.0`) に更新しました。

## 動作確認

- 単体テストが通ること
    - 連絡先追加機能
    - 連絡先削除機能