### PR TITLE
Chapter 2: Navigation stacks

### DIFF
--- a/Chapter2/TCAContacts.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Chapter2/TCAContacts.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "ae491c9e3f66631e72d58db8bb4c27dfc3d3afd4",
-        "version" : "1.6.0"
+        "revision" : "96ce68db884033c4b8ae251cdf11bb47a3e5250f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -82,6 +82,15 @@
       }
     },
     {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "42240120b2a8797595433288ab4118f8042214c3",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
-        "version" : "1.0.2"
+        "revision" : "b58e6627149808b40634c4552fcf2f44d0b3ca87",
+        "version" : "1.1.0"
       }
     }
   ],

--- a/Chapter2/TCAContactsKit/Package.swift
+++ b/Chapter2/TCAContactsKit/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["TCAContactsKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.6.0"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.7.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -30,10 +30,39 @@ struct ContactDetailFeature {
         case deleteButtonTapped
     }
 
+    @Dependency(\.dismiss) var dismiss
+
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .alert(.presented(.confirmDeletion)):
+                return .run { send in
+                    await send(.delegate(.confirmDeletion))
+                    await self.dismiss()
+                }
+
+            case .alert:
+                return .none
+
+            case .delegate:
+                return .none
+
+            case .deleteButtonTapped:
+                state.alert = .confirmDeletion
+                return .none
             }
+        }
+        .ifLet(\.$alert, action: \.alert)
+    }
+}
+
+extension AlertState where Action == ContactDetailFeature.Action.Alert {
+
+    static let confirmDeletion = Self {
+        TextState("Are you sure?")
+    } actions: {
+        ButtonState(role: .destructive, action: .confirmDeletion) {
+            TextState("Delete")
         }
     }
 }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -14,6 +14,7 @@ struct ContactDetailFeature {
 
     @ObservableState
     struct State: Equatable {
+        @Presents var alert: AlertState<Action.Alert>?
         let contact: Contact
     }
 

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -19,6 +19,15 @@ struct ContactDetailFeature {
     }
 
     enum Action {
+        enum Alert {
+            case confirmDeletion
+        }
+        enum Delegate {
+            case confirmDeletion
+        }
+        case alert(PresentationAction<Alert>)
+        case delegate(Delegate)
+        case deleteButtonTapped
     }
 
     var body: some ReducerOf<Self> {

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -33,5 +33,8 @@ struct ContactDetailView: View {
     let store: StoreOf<ContactDetailFeature>
 
     var body: some View {
+        Form {
+        }
+        .navigationBarTitle(Text(store.contact.name))
     }
 }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -30,6 +30,8 @@ struct ContactDetailFeature {
 
 struct ContactDetailView: View {
 
+    let store: StoreOf<ContactDetailFeature>
+
     var body: some View {
     }
 }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -16,4 +16,7 @@ struct ContactDetailFeature {
     struct State: Equatable {
         let contact: Contact
     }
+
+    enum Action {
+    }
 }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -19,4 +19,11 @@ struct ContactDetailFeature {
 
     enum Action {
     }
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            }
+        }
+    }
 }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -11,4 +11,9 @@ import Foundation
 
 @Reducer
 struct ContactDetailFeature {
+
+    @ObservableState
+    struct State: Equatable {
+        let contact: Contact
+    }
 }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -69,12 +69,16 @@ extension AlertState where Action == ContactDetailFeature.Action.Alert {
 
 struct ContactDetailView: View {
 
-    let store: StoreOf<ContactDetailFeature>
+    @Bindable var store: StoreOf<ContactDetailFeature>
 
     var body: some View {
         Form {
+            Button("Delete") {
+                store.send(.deleteButtonTapped)
+            }
         }
         .navigationBarTitle(Text(store.contact.name))
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 }
 

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -7,7 +7,7 @@
 //
 
 import ComposableArchitecture
-import Foundation
+import SwiftUI
 
 @Reducer
 struct ContactDetailFeature {
@@ -25,5 +25,11 @@ struct ContactDetailFeature {
             switch action {
             }
         }
+    }
+}
+
+struct ContactDetailView: View {
+
+    var body: some View {
     }
 }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -1,0 +1,14 @@
+//
+//  ContactDetailFeature.swift
+//
+//  
+//  Created by penguinsan on 2024/02/03
+//  
+//
+
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct ContactDetailFeature {
+}

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactDetailFeature.swift
@@ -38,3 +38,17 @@ struct ContactDetailView: View {
         .navigationBarTitle(Text(store.contact.name))
     }
 }
+
+#Preview {
+    NavigationStack {
+        ContactDetailView(
+            store: Store(
+                initialState: ContactDetailFeature.State(
+                    contact: Contact(id: UUID(), name: "Blob")
+                )
+            ) {
+                ContactDetailFeature()
+            }
+        )
+    }
+}

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -143,6 +143,8 @@ struct ContactsView: View {
                     }
                 }
             }
+        } destination: { store in
+            ContactDetailView(store: store)
         }
         .sheet(
             store: self.store.scope(

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -115,7 +115,7 @@ struct ContactsView: View {
     let store: StoreOf<ContactsFeature>
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             WithViewStore(self.store, observe: \.contacts) { viewStore in
                 List {
                     ForEach(viewStore.state) { contact in

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -30,6 +30,7 @@ struct ContactsFeature {
         case addButtonTapped
         case deleteButtonTapped(id: Contact.ID)
         case destination(PresentationAction<Destination.Action>)
+        case path(StackAction<ContactDetailFeature.State, ContactDetailFeature.Action>)
     }
 
     @Dependency(\.uuid) var uuid
@@ -58,6 +59,9 @@ struct ContactsFeature {
 
             case .deleteButtonTapped(let id):
                 state.destination = .alert(.deleteConfirmation(id: id))
+                return .none
+
+            case .path:
                 return .none
             }
         }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -120,16 +120,19 @@ struct ContactsView: View {
             WithViewStore(self.store, observe: \.contacts) { viewStore in
                 List {
                     ForEach(viewStore.state) { contact in
-                        HStack {
-                            Text(contact.name)
-                            Spacer()
-                            Button {
-                                viewStore.send(.deleteButtonTapped(id: contact.id))
-                            } label: {
-                                Image(systemName: "trash")
-                                    .foregroundColor(.red)
+                        NavigationLink(state: ContactDetailFeature.State(contact: contact)) {
+                            HStack {
+                                Text(contact.name)
+                                Spacer()
+                                Button {
+                                    viewStore.send(.deleteButtonTapped(id: contact.id))
+                                } label: {
+                                    Image(systemName: "trash")
+                                        .foregroundColor(.red)
+                                }
                             }
                         }
+                        .buttonStyle(.borderless)
                     }
                 }
                 .navigationTitle("Contacts")

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -68,6 +68,9 @@ struct ContactsFeature {
         .ifLet(\.$destination, action: \.destination) {
             Destination()
         }
+        .forEach(\.path, action: \.path) {
+            ContactDetailFeature()
+        }
     }
 }
 

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -20,6 +20,7 @@ struct ContactsFeature {
     struct State: Equatable {
         var contacts: IdentifiedArrayOf<Contact> = []
         @PresentationState var destination: Destination.State?
+        var path = StackState<ContactDetailFeature.State>()
     }
 
     enum Action {

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -62,6 +62,13 @@ struct ContactsFeature {
                 state.destination = .alert(.deleteConfirmation(id: id))
                 return .none
 
+            case .path(.element(let id, action: .delegate(.confirmDeletion))):
+                guard let detailState = state.path[id: id] else {
+                    return .none
+                }
+                state.contacts.remove(id: detailState.contact.id)
+                return .none
+
             case .path:
                 return .none
             }

--- a/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
+++ b/Chapter2/TCAContactsKit/Sources/TCAContactsKit/ContactsFeature.swift
@@ -17,9 +17,10 @@ struct Contact: Equatable, Identifiable {
 @Reducer
 struct ContactsFeature {
 
+    @ObservableState
     struct State: Equatable {
         var contacts: IdentifiedArrayOf<Contact> = []
-        @PresentationState var destination: Destination.State?
+        @Presents var destination: Destination.State?
         var path = StackState<ContactDetailFeature.State>()
     }
 
@@ -112,7 +113,7 @@ extension AlertState where Action == ContactsFeature.Action.Alert {
 
 struct ContactsView: View {
 
-    let store: StoreOf<ContactsFeature>
+    @Bindable var store: StoreOf<ContactsFeature>
 
     var body: some View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {


### PR DESCRIPTION
## 概要

The Composable Architecture Tutorials の [Chapter 2 Navigation: Navigation stacks](https://pointfreeco.github.io/swift-composable-architecture/main/tutorials/composablearchitecture/02-04-navigationstacks) を実施する。

Tutorial の途中でバージョン `1.6.0` では実装されていないメソッドが使われていたため、TCA のバージョンを最新 (`1.7.2`) に更新しました。

## スクショ

| | |
| --- | --- |
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-18 at 16 14 12](https://github.com/penguinsan-pg/tca-tutorial/assets/123573709/009790a5-a09d-4dde-a481-3f0b1e221a4c) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-18 at 16 14 17](https://github.com/penguinsan-pg/tca-tutorial/assets/123573709/27eb138a-007f-405c-813a-f1ff59a16aa7) |
